### PR TITLE
Missing import

### DIFF
--- a/manuals/views/step3.md
+++ b/manuals/views/step3.md
@@ -353,6 +353,7 @@ This is a structure of the Socially app:
 @@ -0,0 +1,27 @@
 +┊  ┊ 1┊import angular from 'angular';
 +┊  ┊ 2┊import angularMeteor from 'angular-meteor';
+        import { Parties } from '../../../../collections/parties';
 +┊  ┊ 3┊
 +┊  ┊ 4┊class PartiesList {
 +┊  ┊ 5┊  constructor($scope, $reactive) {


### PR DESCRIPTION
The import @line 356 was missing and throwing an error. Due to this the party list is not getting displayed.
The File Name is partiesList.js
The updated code is below :

##### Added imports/ui/components/partiesList/partiesList.js
```diff
@@ -0,0 +1,27 @@
+┊  ┊ 1┊import angular from 'angular';
+┊  ┊ 2┊import angularMeteor from 'angular-meteor';
                  import { Parties } from '../../../../collections/parties';
+┊  ┊ 3┊
+┊  ┊ 4┊class PartiesList {
+┊  ┊ 5┊  constructor($scope, $reactive) {
+┊  ┊ 6┊    'ngInject';
+┊  ┊ 7┊
+┊  ┊ 8┊    $reactive(this).attach($scope);
+┊  ┊ 9┊
+┊  ┊10┊    this.helpers({
+┊  ┊11┊      parties() {
+┊  ┊12┊        return Parties.find({});
+┊  ┊13┊      }
+┊  ┊14┊    });
+┊  ┊15┊  }
+┊  ┊16┊}
+┊  ┊17┊
+┊  ┊18┊const name = 'partiesList';
+┊  ┊19┊
+┊  ┊20┊// create a module
+┊  ┊21┊export default angular.module(name, [
+┊  ┊22┊  angularMeteor
+┊  ┊23┊]).component(name, {
+┊  ┊24┊  templateUrl: `imports/ui/components/${name}/${name}.html`,
+┊  ┊25┊  controllerAs: name,
+┊  ┊26┊  controller: PartiesList
+┊  ┊27┊});